### PR TITLE
ux: change group event

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -570,8 +570,8 @@ function OpenPermsMenu(permsply)
                     value = 'god',
                     description = 'Group'
                 }},
-                select = function(btn)
-                    local vcal = btn.Value
+                change = function(item, newValue, oldValue)
+                    local vcal = newValue
                     if vcal == 1 then
                         selectedgroup = {}
                         table.insert(selectedgroup, {rank = "user", label = "User"})


### PR DESCRIPTION
It is very difficult for people to select the authorization and press the "enter" key, I could hardly understand this even by reading the codes. Now it is enough to change it with the right-left arrow keys.