### PR TITLE
feat: added group change notification

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -593,6 +593,7 @@ function OpenPermsMenu(permsply)
                 select = function(btn)
                     if selectedgroup ~= 'Unknown' then
                         TriggerServerEvent('qb-admin:server:setPermissions', permsply.id, selectedgroup)
+			QBCore.Functions.Notify('Authority group changed!', 'success')
                         selectedgroup = 'Unknown'
                     else
                         QBCore.Functions.Notify('Choose a group!', 'error')


### PR DESCRIPTION
When assigned to a new group, no notification appeared that the action had taken place.
I added this.