### PR TITLE
Fix exploitable event "qb-admin:server:setPermissions"

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -199,8 +199,11 @@ end)
 
 RegisterServerEvent('qb-admin:server:setPermissions')
 AddEventHandler('qb-admin:server:setPermissions', function(targetId, group)
-    QBCore.Functions.AddPermission(targetId, group[1].rank)
-    TriggerClientEvent('QBCore:Notify', targetId, 'Your Permission Level Is Now '..group[1].label)
+    local src = source
+    if QBCore.Functions.HasPermission(src, "admin") then
+        QBCore.Functions.AddPermission(targetId, group[1].rank)
+        TriggerClientEvent('QBCore:Notify', targetId, 'Your Permission Level Is Now '..group[1].label)
+    end
 end)
 
 RegisterServerEvent('qb-admin:server:SendReport')


### PR DESCRIPTION
This event can be abused with a lua executor to get god permissions on any server currently.