### PR TITLE
remove: default text in input boxes

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -716,7 +716,7 @@ local function OpenKickMenu(kickplayer)
         value = "reason",
         description = 'Kick reason',
         select = function(btn)
-            kickreason = LocalInput('Kick Reason', 255, 'Reason')
+            kickreason = LocalInput('Kick Reason', 255)
         end
     })
 
@@ -745,7 +745,7 @@ local function OpenBanMenu(banplayer)
         value = "reason",
         description = 'Ban reason',
         select = function(btn)
-            banreason = LocalInput('Ban Reason', 255, 'Reason')
+            banreason = LocalInput('Ban Reason', 255)
         end
     })
 
@@ -804,7 +804,7 @@ local function OpenBanMenu(banplayer)
         }},
         select = function(btn, newValue, oldValue)
             if newValue == "self" then
-                banlength = LocalInputInt('Ban Length', 11, 'Seconds')
+                banlength = LocalInputInt('Ban Length', 11)
             else
                 banlength = newValue
             end


### PR DESCRIPTION
**Describe Pull request**
Removed useless default text in the input boxes for banning and kicking. Gets really frustrating when banning someone and you have to delete the default text.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
