### PR TITLE
Dev mode for qb-hud (adds radial & invincibility)

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -340,6 +340,14 @@ local vehicledev_button = menu11:AddButton({
     value = nil,
     description = Lang:t("desc.vehicle_dev_mode_desc")
 })
+
+local menu_dev_button = menu11:AddCheckbox({
+    icon = '⚫',
+    label = 'Dev Mode',
+    value = menu11,
+    description = 'Enable/Disable Developer Mode'
+})
+
 local deletelazer_button = menu11:AddCheckbox({
     icon = '🔫',
     label = Lang:t("menu.delete_laser"),
@@ -377,6 +385,19 @@ local menu12_button4 = menu12:AddButton({
     value = 'remove',
     description = Lang:t("desc.remove_vehicle_desc")
 })
+
+local dev = false
+menu_dev_button:On('change', function(item, newValue, oldValue)
+    dev = not dev
+    TriggerEvent('qb-admin:client:ToggleDevmode')
+    if dev then
+        while dev do
+            Wait(200)
+            SetPlayerInvincible(PlayerId(), true)
+        end
+            SetPlayerInvincible(PlayerId(), false)
+    end
+end)
 
 local deleteLazer = false
 deletelazer_button:On('change', function(item, newValue, oldValue)


### PR DESCRIPTION
**Describe Pull request**
This feature will work in unison with newest qb-hud (adds dev mode as an option that can be found in "Developer Options" selection menu, it will allow players to be invincible while also having a developer icon displayed in the radials (qb-hud). 

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
