### PR TITLE
Adding utility position getter commands

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -513,7 +513,15 @@ end
 
 local function CopyToClipboard(dataType)
     local ped = PlayerPedId()
-    if dataType == 'coords3' then
+    if dataType == 'coords2' then
+        local coords = GetEntityCoords(ped)
+        local x = round(coords.x, 2)
+        local y = round(coords.y, 2)
+        SendNUIMessage({
+            string = string.format('vector2(%s, %s)', x, y)
+        })
+        QBCore.Functions.Notify(Lang:t("success.coords_copied"), "success")
+    elseif dataType == 'coords3' then
         local coords = GetEntityCoords(ped)
         local x = round(coords.x, 2)
         local y = round(coords.y, 2)
@@ -565,6 +573,10 @@ local function CopyToClipboard(dataType)
         end
     end
 end
+
+RegisterNetEvent('qb-admin:client:copyToClipboard', function(dataType)
+    CopyToClipboard(dataType)
+end)
 
 local function Draw2DText(content, font, colour, scale, x, y)
     SetTextFont(font)

--- a/server/server.lua
+++ b/server/server.lua
@@ -429,6 +429,26 @@ QBCore.Commands.Add('setammo', Lang:t("commands.ammo_amount_set"), {{name='amoun
     end
 end, 'admin')
 
+QBCore.Commands.Add('vector2', 'Copy vector2 to clipboard (Admin only)', {}, false, function(source)
+    local src = source
+    TriggerClientEvent('qb-admin:client:copyToClipboard', src, 'coords2')
+end, 'admin')
+
+QBCore.Commands.Add('vector3', 'Copy vector3 to clipboard (Admin only)', {}, false, function(source)
+    local src = source
+    TriggerClientEvent('qb-admin:client:copyToClipboard', src, 'coords3')
+end, 'admin')
+
+QBCore.Commands.Add('vector4', 'Copy vector4 to clipboard (Admin only)', {}, false, function(source)
+    local src = source
+    TriggerClientEvent('qb-admin:client:copyToClipboard', src, 'coords4')
+end, 'admin')
+
+QBCore.Commands.Add('heading', 'Copy heading to clipboard (Admin only)', {}, false, function(source)
+    local src = source
+    TriggerClientEvent('qb-admin:client:copyToClipboard', src, 'heading')
+end, 'admin')
+
 CreateThread(function()
     while true do
         local tempPlayers = {}


### PR DESCRIPTION
This adds some utility commands for copying coordinates (vec2, vec3, vec4 and heading) to clipboard.

Making these commands available can improve developers efficiency, especially when combined with `qb-commandbinding` (Experienced it myself when moving garage points in qb-garages)