### PR TITLE
Update en.lua

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -24,6 +24,7 @@ local Translations = {
         ["entered_vehicle"] = "Entered vehicle",
         ["success_vehicle_owner"] = "The vehicle is now yours!",
         ["receive_reports"] = "You are receiving reports",
+        ["sucess.entered_vehicle"] = "success Entered vehicle",
     },
     info = {
         ["ped_coords"] = "Ped Coordinates:",


### PR DESCRIPTION
The following error: [ script:qb-adminmenu] Warning: Missing phrase for key: "sucess.entered_vehicle"

The entire line was missing in the en.lua ["sucess.entered_vehicle"] = "success Entered vehicle",

I added it and fixed the bug
