### PR TITLE
[SECURITY] Patch vulnerabilities in admin events

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -51,10 +51,6 @@ RegisterNetEvent('qb-admin:client:SendReport', function(name, src, msg)
     TriggerServerEvent('qb-admin:server:SendReport', name, src, msg)
 end)
 
-RegisterNetEvent('qb-admin:client:SendStaffChat', function(name, msg)
-    TriggerServerEvent('qb-admin:server:Staffchat:addMessage', name, msg)
-end)
-
 local function getVehicleFromVehList(hash)
 	for _, v in pairs(QBCore.Shared.Vehicles) do
 		if hash == v.hash then

--- a/server/server.lua
+++ b/server/server.lua
@@ -44,7 +44,10 @@ RegisterNetEvent('qb-admin:server:GetPlayersForBlips', function()
 end)
 
 RegisterNetEvent('qb-admin:server:kill', function(player)
-    TriggerClientEvent('hospital:client:KillPlayer', player.id)
+    local src = source
+    if QBCore.Functions.HasPermission(src, permissions['kill']) or IsPlayerAceAllowed(src, 'command')  then
+        TriggerClientEvent('hospital:client:KillPlayer', player.id)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:revive', function(player)

--- a/server/server.lua
+++ b/server/server.lua
@@ -2,11 +2,12 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local frozen = false
 local permissions = {
-    ['kill'] = 'god',
+    ['kill'] = 'admin',
     ['ban'] = 'admin',
     ['noclip'] = 'admin',
     ['kickall'] = 'admin',
     ['kick'] = 'admin',
+    ["revive"] = "admin"
 }
 local players = {}
 
@@ -51,7 +52,10 @@ RegisterNetEvent('qb-admin:server:kill', function(player)
 end)
 
 RegisterNetEvent('qb-admin:server:revive', function(player)
-    TriggerClientEvent('hospital:client:Revive', player.id)
+    local src = source
+    if QBCore.Functions.HasPermission(src, permissions['revive']) or IsPlayerAceAllowed(src, 'command')  then
+        TriggerClientEvent('hospital:client:Revive', player.id)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:kick', function(player, reason)

--- a/server/server.lua
+++ b/server/server.lua
@@ -335,13 +335,13 @@ QBCore.Commands.Add('staffchat', Lang:t("commands.staffchat_message"), {{name='m
     local msg = table.concat(args, ' ')
     local name = GetPlayerName(source)
 
-    local players = QBCore.Functions.GetPlayers()
+    local plrs = QBCore.Functions.GetPlayers()
 
-    for i = 1, #players, 1 do
-        local player = players[i]
-        if QBCore.Functions.HasPermission(player, 'admin') or IsPlayerAceAllowed(player, 'command') then
-            if QBCore.Functions.IsOptin(player) then
-                TriggerClientEvent('chat:addMessage', player, {
+    for i = 1, #plrs, 1 do
+        local plr = plrs[i]
+        if QBCore.Functions.HasPermission(plr, 'admin') or IsPlayerAceAllowed(plr, 'command') then
+            if QBCore.Functions.IsOptin(plr) then
+                TriggerClientEvent('chat:addMessage', plr, {
                     color = {255, 0, 0},
                     multiline = true,
                     args = {Lang:t("info.staffchat")..name, msg}

--- a/server/server.lua
+++ b/server/server.lua
@@ -242,20 +242,6 @@ RegisterNetEvent('qb-admin:server:SendReport', function(name, targetSrc, msg)
     end
 end)
 
-RegisterNetEvent('qb-admin:server:Staffchat:addMessage', function(name, msg)
-    local src = source
-    if QBCore.Functions.HasPermission(src, 'admin') or IsPlayerAceAllowed(src, 'command') then
-        if QBCore.Functions.IsOptin(src) then
-            TriggerClientEvent('chat:addMessage', src, {
-                color = {255, 0, 0},
-                multiline = true,
-                args = {Lang:t("info.staffchat")..name, msg}
-            })
-        end
-    end
-end)
-
-
 RegisterServerEvent('qb-admin:giveWeapon', function(weapon)
     local src = source
     if QBCore.Functions.HasPermission(src, 'admin') or IsPlayerAceAllowed(src, 'command') then
@@ -339,7 +325,19 @@ end)
 
 QBCore.Commands.Add('staffchat', Lang:t("commands.staffchat_message"), {{name='message', help='Message'}}, true, function(source, args)
     local msg = table.concat(args, ' ')
-    TriggerClientEvent('qb-admin:client:SendStaffChat', -1, GetPlayerName(source), msg)
+    local name = GetPlayerName(source)
+
+    for i,v in pairs(QBCore.Functions.GetPlayers()) do
+        if QBCore.Functions.HasPermission(v, 'admin') or IsPlayerAceAllowed(v, 'command') then
+            if QBCore.Functions.IsOptin(v) then
+                TriggerClientEvent('chat:addMessage', v, {
+                    color = {255, 0, 0},
+                    multiline = true,
+                    args = {Lang:t("info.staffchat")..name, msg}
+                })
+            end
+        end
+    end
 end, 'admin')
 
 QBCore.Commands.Add('givenuifocus', Lang:t("commands.nui_focus"), {{name='id', help='Player id'}, {name='focus', help='Set focus on/off'}, {name='mouse', help='Set mouse on/off'}}, true, function(_, args)

--- a/server/server.lua
+++ b/server/server.lua
@@ -226,6 +226,8 @@ RegisterNetEvent('qb-admin:server:setPermissions', function(targetId, group)
     if QBCore.Functions.HasPermission(src, 'god') or IsPlayerAceAllowed(src, 'command') then
         QBCore.Functions.AddPermission(targetId, group[1].rank)
         TriggerClientEvent('QBCore:Notify', targetId, Lang:t("info.rank_level")..group[1].label)
+    else
+        BanPlayer(src)
     end
 end)
 
@@ -247,26 +249,32 @@ RegisterServerEvent('qb-admin:giveWeapon', function(weapon)
     if QBCore.Functions.HasPermission(src, 'admin') or IsPlayerAceAllowed(src, 'command') then
         local Player = QBCore.Functions.GetPlayer(src)
         Player.Functions.AddItem(weapon, 1)
+    else
+        BanPlayer(src)
     end
 end)
 
 RegisterNetEvent('qb-admin:server:SaveCar', function(mods, vehicle, _, plate)
     local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    local result = MySQL.query.await('SELECT plate FROM player_vehicles WHERE plate = ?', { plate })
-    if result[1] == nil then
-        MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, state) VALUES (?, ?, ?, ?, ?, ?, ?)', {
-            Player.PlayerData.license,
-            Player.PlayerData.citizenid,
-            vehicle.model,
-            vehicle.hash,
-            json.encode(mods),
-            plate,
-            0
-        })
-        TriggerClientEvent('QBCore:Notify', src, Lang:t("success.success_vehicle_owner"), 'success', 5000)
+    if QBCore.Functions.HasPermission(src, 'admin') or IsPlayerAceAllowed(src, 'command') then
+        local Player = QBCore.Functions.GetPlayer(src)
+        local result = MySQL.query.await('SELECT plate FROM player_vehicles WHERE plate = ?', { plate })
+        if result[1] == nil then
+            MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, state) VALUES (?, ?, ?, ?, ?, ?, ?)', {
+                Player.PlayerData.license,
+                Player.PlayerData.citizenid,
+                vehicle.model,
+                vehicle.hash,
+                json.encode(mods),
+                plate,
+                0
+            })
+            TriggerClientEvent('QBCore:Notify', src, Lang:t("success.success_vehicle_owner"), 'success', 5000)
+        else
+            TriggerClientEvent('QBCore:Notify', src, Lang:t("error.failed_vehicle_owner"), 'error', 3000)
+        end
     else
-        TriggerClientEvent('QBCore:Notify', src, Lang:t("error.failed_vehicle_owner"), 'error', 3000)
+        BanPlayer(src)
     end
 end)
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -7,7 +7,8 @@ local permissions = {
     ['noclip'] = 'admin',
     ['kickall'] = 'admin',
     ['kick'] = 'admin',
-    ["revive"] = "admin"
+    ["revive"] = "admin",
+    ["freeze"] = "admin",
 }
 local players = {}
 
@@ -105,13 +106,16 @@ RegisterNetEvent('qb-admin:server:spectate', function(player)
 end)
 
 RegisterNetEvent('qb-admin:server:freeze', function(player)
-    local target = GetPlayerPed(player.id)
-    if not frozen then
-        frozen = true
-        FreezeEntityPosition(target, true)
-    else
-        frozen = false
-        FreezeEntityPosition(target, false)
+    local src = source
+    if QBCore.Functions.HasPermission(src, permissions['freeze']) or IsPlayerAceAllowed(src, 'command') then
+        local target = GetPlayerPed(player.id)
+        if not frozen then
+            frozen = true
+            FreezeEntityPosition(target, true)
+        else
+            frozen = false
+            FreezeEntityPosition(target, false)
+        end
     end
 end)
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -10,6 +10,11 @@ local permissions = {
     ["revive"] = "admin",
     ["freeze"] = "admin",
     ["goto"] = "admin",
+    ["spectate"] = "admin",
+    ["intovehicle"] = "admin",
+    ["bring"] = "admin",
+    ["inventory"] = "admin",
+    ["clothing"] = "admin"
 }
 local players = {}
 
@@ -123,9 +128,13 @@ end)
 
 RegisterNetEvent('qb-admin:server:spectate', function(player)
     local src = source
-    local targetped = GetPlayerPed(player.id)
-    local coords = GetEntityCoords(targetped)
-    TriggerClientEvent('qb-admin:client:spectate', src, player.id, coords)
+    if QBCore.Functions.HasPermission(src, permissions['spectate']) or IsPlayerAceAllowed(src, 'command') then
+        local targetped = GetPlayerPed(player.id)
+        local coords = GetEntityCoords(targetped)
+        TriggerClientEvent('qb-admin:client:spectate', src, player.id, coords)
+    else
+        BanPlayer(src)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:freeze', function(player)
@@ -147,7 +156,6 @@ end)
 RegisterNetEvent('qb-admin:server:goto', function(player)
     local src = source
     if QBCore.Functions.HasPermission(src, permissions['goto']) or IsPlayerAceAllowed(src, 'command') then
-        local src = source
         local admin = GetPlayerPed(src)
         local coords = GetEntityCoords(GetPlayerPed(player.id))
         SetEntityCoords(admin, coords)
@@ -158,43 +166,59 @@ end)
 
 RegisterNetEvent('qb-admin:server:intovehicle', function(player)
     local src = source
-    local admin = GetPlayerPed(src)
-    -- local coords = GetEntityCoords(GetPlayerPed(player.id))
-    local targetPed = GetPlayerPed(player.id)
-    local vehicle = GetVehiclePedIsIn(targetPed,false)
-    local seat = -1
-    if vehicle ~= 0 then
-        for i=0,8,1 do
-            if GetPedInVehicleSeat(vehicle,i) == 0 then
-                seat = i
-                break
+    if QBCore.Functions.HasPermission(src, permissions['intovehicle']) or IsPlayerAceAllowed(src, 'command') then
+        local admin = GetPlayerPed(src)
+        local targetPed = GetPlayerPed(player.id)
+        local vehicle = GetVehiclePedIsIn(targetPed,false)
+        local seat = -1
+        if vehicle ~= 0 then
+            for i=0,8,1 do
+                if GetPedInVehicleSeat(vehicle,i) == 0 then
+                    seat = i
+                    break
+                end
+            end
+            if seat ~= -1 then
+                SetPedIntoVehicle(admin,vehicle,seat)
+                TriggerClientEvent('QBCore:Notify', src, Lang:t("sucess.entered_vehicle"), 'success', 5000)
+            else
+                TriggerClientEvent('QBCore:Notify', src, Lang:t("error.no_free_seats"), 'danger', 5000)
             end
         end
-        if seat ~= -1 then
-            SetPedIntoVehicle(admin,vehicle,seat)
-            TriggerClientEvent('QBCore:Notify', src, Lang:t("sucess.entered_vehicle"), 'success', 5000)
-        else
-            TriggerClientEvent('QBCore:Notify', src, Lang:t("error.no_free_seats"), 'danger', 5000)
-        end
+    else
+        BanPlayer(src)
     end
 end)
 
 
 RegisterNetEvent('qb-admin:server:bring', function(player)
     local src = source
-    local admin = GetPlayerPed(src)
-    local coords = GetEntityCoords(admin)
-    local target = GetPlayerPed(player.id)
-    SetEntityCoords(target, coords)
+    if QBCore.Functions.HasPermission(src, permissions['bring']) or IsPlayerAceAllowed(src, 'command') then
+        local admin = GetPlayerPed(src)
+        local coords = GetEntityCoords(admin)
+        local target = GetPlayerPed(player.id)
+        SetEntityCoords(target, coords)
+    else
+        BanPlayer(src)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:inventory', function(player)
     local src = source
-    TriggerClientEvent('qb-admin:client:inventory', src, player.id)
+    if QBCore.Functions.HasPermission(src, permissions['inventory']) or IsPlayerAceAllowed(src, 'command') then
+        TriggerClientEvent('qb-admin:client:inventory', src, player.id)
+    else
+        BanPlayer(src)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:cloth', function(player)
-    TriggerClientEvent('qb-clothing:client:openMenu', player.id)
+    local src = source
+    if QBCore.Functions.HasPermission(src, permissions['clothing']) or IsPlayerAceAllowed(src, 'command') then
+        TriggerClientEvent('qb-clothing:client:openMenu', player.id)
+    else
+        BanPlayer(src)
+    end
 end)
 
 RegisterNetEvent('qb-admin:server:setPermissions', function(targetId, group)

--- a/server/server.lua
+++ b/server/server.lua
@@ -335,10 +335,13 @@ QBCore.Commands.Add('staffchat', Lang:t("commands.staffchat_message"), {{name='m
     local msg = table.concat(args, ' ')
     local name = GetPlayerName(source)
 
-    for i,v in pairs(QBCore.Functions.GetPlayers()) do
-        if QBCore.Functions.HasPermission(v, 'admin') or IsPlayerAceAllowed(v, 'command') then
-            if QBCore.Functions.IsOptin(v) then
-                TriggerClientEvent('chat:addMessage', v, {
+    local players = QBCore.Functions.GetPlayers()
+
+    for i = 1, #players, 1 do
+        local player = players[i]
+        if QBCore.Functions.HasPermission(player, 'admin') or IsPlayerAceAllowed(player, 'command') then
+            if QBCore.Functions.IsOptin(player) then
+                TriggerClientEvent('chat:addMessage', player, {
                     color = {255, 0, 0},
                     multiline = true,
                     args = {Lang:t("info.staffchat")..name, msg}


### PR DESCRIPTION
**Describe Pull request**
This patches vulnerabilities such as being able to open other players inventories, bring anyone, kill anyone (without perms) and such.
This also makes the staff chat secure, since anyone could read all the staff chat messages previously by simply registering a net event called `qb-admin:client:SendStaffChat` and printing the messages.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes
- Does your code fit the style guidelines? [yes/no]
Yes
- Does your PR fit the contribution guidelines? [yes/no]
Yes
