### PR TITLE
Adding sorting in vehicle categories and vehicle list + modelname in vehicle spawn description + missing de.lua locale keys

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -940,7 +940,7 @@ local function OpenCarModelsMenu(category)
 	            description = 'Spawn ' .. v["name"] .. ' (' .. v['model'] .. ')',
 	            select = function(_)
 			if sortVehiclesAndCategories then
-	                	TriggerServerEvent('QBCore:CallCommand', "car", { v['model'] })
+				TriggerServerEvent('QBCore:CallCommand', "car", { v['model'] })
                         else
 				TriggerServerEvent('QBCore:CallCommand', "car", { k })
 			end

--- a/client/client.lua
+++ b/client/client.lua
@@ -871,25 +871,25 @@ end
 
 -- Sort Vehicles and Categories if enabled
 if sortVehiclesAndCategories then
-    local i = 1 
+    local i = 1
     local vehicleCategories = {}
     
-    for k,v in pairs(vehicles) do
+    for k,_ in pairs(vehicles) do
         vehicleCategories[k] = {}
-        for a,b in pairs(vehicles[k]) do
+        for _,b in pairs(vehicles[k]) do
             vehicleCategories[k][i] = {}
             vehicleCategories[k][i] = b
             i = i+1
         end
-    end  
+    end
 
-    for k,v in pairs(vehicleCategories) do
+    for k,_ in pairs(vehicleCategories) do
         for _,_ in pairs(vehicleCategories[k]) do
-            for a,b in pairs(vehicleCategories[k]) do
+            for a,_ in pairs(vehicleCategories[k]) do
                 local c1 = string.sub(vehicleCategories[k][a]['name'],1,1)
 
                 if vehicleCategories[k][a+1] then
-                    local c2 = string.sub(vehicleCategories[k][a+1]['name'],1,1) 
+                    local c2 = string.sub(vehicleCategories[k][a+1]['name'],1,1)
 
                     if c1 > c2 then
                         local VehiclesAndCatsSorted = vehicleCategories[k][a]
@@ -902,7 +902,6 @@ if sortVehiclesAndCategories then
     end
 
     local VehiclesAndCatsSorted = {}
-    local l = 1
     for key,value in pairs(vehicleCategories) do
         VehiclesAndCatsSorted[i] = {}
         VehiclesAndCatsSorted[i]['name'] = key
@@ -942,7 +941,7 @@ local function OpenCarModelsMenu(category)
 	            select = function(_)
 			if sortVehiclesAndCategories then
 	                	TriggerServerEvent('QBCore:CallCommand', "car", { v['model'] })
-			else
+                        else
 				TriggerServerEvent('QBCore:CallCommand', "car", { k })
 			end
 	            end

--- a/client/client.lua
+++ b/client/client.lua
@@ -938,7 +938,7 @@ local function OpenCarModelsMenu(category)
 	        menu13:AddButton({
 	            label = v["name"],
 	            value = k,
-	            description = 'Spawn ' .. v["name"],
+	            description = 'Spawn ' .. v["name"] .. '(' .. v['model'] .. ')',
 	            select = function(_)
 			if sortVehiclesAndCategories then
 	                	TriggerServerEvent('QBCore:CallCommand', "car", { v['model'] })

--- a/client/client.lua
+++ b/client/client.lua
@@ -938,7 +938,7 @@ local function OpenCarModelsMenu(category)
 	        menu13:AddButton({
 	            label = v["name"],
 	            value = k,
-	            description = 'Spawn ' .. v["name"] .. '(' .. v['model'] .. ')',
+	            description = 'Spawn ' .. v["name"] .. ' (' .. v['model'] .. ')',
 	            select = function(_)
 			if sortVehiclesAndCategories then
 	                	TriggerServerEvent('QBCore:CallCommand', "car", { v['model'] })

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -149,6 +149,9 @@ local Translations = {
         ["entity_view_vehicles"] = "Fahrzeuge anzeigen",
         ["entity_view_objects"] = "Objekte anzeigen",
         ["entity_view_freeaim_copy"] = "Freeaim-Entitätsinformationen kopieren",
+        ["spawn_weapons"] = "Waffen spawnen",
+        ["max_mods"] = "Fahrzeug tunen",
+        ["hud_dev_mode"] = "Entwicklermodus (qb-hud)"
     },
     desc = {
         ["admin_options_desc"] = "Verschiedene. Admin Optionen",
@@ -189,6 +192,9 @@ local Translations = {
         ["entity_view_vehicles_desc"] = "Fahrzeuginformationen in der Welt aktivieren/deaktivieren",
         ["entity_view_objects_desc"] = "Objektinformationen in der Welt aktivieren/deaktivieren",
         ["entity_view_freeaim_copy_desc"] = "Kopiert die Free Aim Entitätsinfo in die Zwischenablage",
+        ["spawn_weapons_desc"] = "Spawne jede Waffe",
+        ["max_mod_desc"] = "Tune das Fahrzeug maximal",
+        ["hud_dev_mode_desc"] = "An/Aus Entwicklermodus"
     },
     time = {
         ["ban_length"] = "Ban Länge",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -26,6 +26,8 @@ local Translations = {
         ["success_vehicle_owner"] = "Das Fahrzeug ist nicht deins!",
         ["receive_reports"] = "Du erhälst Reports",
         ["entity_copy"] = "Freeaim-Entitätsinfo in die Zwischenablage kopiert!",
+        ["noclip_enabled"] = "NoClip aktiviert!",
+        ["noclip_disabled"] = "NoClip deaktiviert!"
     },
     info = {
         ["ped_coords"] = "Ped Koordinaten:",


### PR DESCRIPTION
**Describe Pull request**
The unsorted category list of the vehicles and the unsorted vehicles are always annoying because you keep looking for dead because the sorting is different every time you restart. With this solution it is now properly sorted. In addition, a vehicle's spawn code is also displayed for /car.

Finally, I also added some missing language translations

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
YES
- Does your code fit the style guidelines? [yes/no]
Guess yes
- Does your PR fit the contribution guidelines? [yes/no]
YES