### PR TITLE
added send to swim command

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -151,7 +151,6 @@ RegisterNetEvent('qb-admin:client:maxmodVehicle', function()
 end)
 
 RegisterNetEvent('qb-admin:client:sendtoswim',function(id,reason)
-    local src = source
     local ped = PlayerPedId(id)
     local coords = vector3(-4915.85, -3057.73, -0.94)
     QBCore.Functions.Notify(reason, 'error')

--- a/client/events.lua
+++ b/client/events.lua
@@ -149,3 +149,11 @@ RegisterNetEvent('qb-admin:client:maxmodVehicle', function()
     local vehicle = GetVehiclePedIsIn(PlayerPedId())
     PerformanceUpgradeVehicle(vehicle)
 end)
+
+RegisterNetEvent('qb-admin:client:sendtoswim',function(id,reason)
+    local src = source
+    local ped = PlayerPedId(id)
+    local coords = vector3(-4915.85, -3057.73, -0.94)
+    QBCore.Functions.Notify(reason, 'error')
+    SetEntityCoords(ped, coords.x, coords.y, coords.z)
+end)

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -269,6 +269,7 @@ local Translations = {
         report_toggle = 'Toggle Incoming Reports (Admin Only)',
         kick_all = 'Kick all players',
         ammo_amount_set = 'Set Your Ammo Amount (Admin Only)',
+        sendtoswim = "Send player to swimming (Admin Only)",
     }
 }
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -522,6 +522,12 @@ QBCore.Commands.Add('heading', 'Copy heading to clipboard (Admin only)', {}, fal
     TriggerClientEvent('qb-admin:client:copyToClipboard', src, 'heading')
 end, 'admin')
 
+QBCore.Commands.Add('sendtoswim', Lang:t('commands.sendtoswim'), { { name = 'id', help = 'Player id' }, { name = 'Reason', help = 'Reason to send to swim' }, }, true, function(_, args)
+    local playerid = tonumber(args[1])
+    local reason = table.concat(args, " ",2)
+    TriggerClientEvent('qb-admin:client:sendtoswim', playerid,playerid, reason)
+end, 'admin')
+
 CreateThread(function()
     while true do
         local tempPlayers = {}


### PR DESCRIPTION
added send to swim feature for admins

**Describe Pull request**
Added send to swim command in adminmenu this will be helpfull for the admins to send problematic players to the ocean to swim back to the land

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
