### PR TITLE
Changed the set permissions to clear old permissions before adding new ones

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -223,6 +223,7 @@ end)
 RegisterNetEvent('qb-admin:server:setPermissions', function(targetId, group)
     local src = source
     if QBCore.Functions.HasPermission(src, 'god') or IsPlayerAceAllowed(src, 'command') then
+        QBCore.Functions.RemovePermission(targetId)
         QBCore.Functions.AddPermission(targetId, group[1].rank)
         TriggerClientEvent('QBCore:Notify', targetId, Lang:t('info.rank_level') .. group[1].label)
     else


### PR DESCRIPTION
Simple PR to make the "set permission" feature actually work like a "set" and not simply and "add".  Removes all ranks prior to assigning a new one.

PR goes in hand with [This Core PR](https://github.com/qbcore-framework/qb-core/pull/1118)

First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
